### PR TITLE
feat: add combobox prop focusOnHover

### DIFF
--- a/src/components/VvCombobox/VvCombobox.vue
+++ b/src/components/VvCombobox/VvCombobox.vue
@@ -562,7 +562,7 @@ export default {
                                     }"
                                     :key="i"
                                     class="vv-dropdown-option"
-                                    focus-on-hover
+                                    :focus-on-hover="focusOnHover"
                                     @click.passive="onInput(item)"
                                 >
                                     <!-- @slot Slot for option customization -->
@@ -593,7 +593,7 @@ export default {
                                         propsDefaults.selectedHintLabel,
                                 }"
                                 class="vv-dropdown-option"
-                                focus-on-hover
+                                :focus-on-hover="focusOnHover"
                                 @click.passive="onInput(option)"
                             >
                                 <!-- @slot Slot for option customization -->

--- a/src/components/VvCombobox/index.ts
+++ b/src/components/VvCombobox/index.ts
@@ -196,6 +196,13 @@ export const VvComboboxProps = {
         type: Boolean,
         default: false,
     },
+    /**
+     * Focus on hover option (this prop remove the focus from the input search)
+     */
+    focusOnHover: {
+        type: Boolean,
+        default: true,
+    },
 }
 
 // WARNING: This is a provisiaonal implementation, it may change in the future


### PR DESCRIPTION
use this prop to manage dropdown item option focus on hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dropdown interaction by enabling dynamic focus behavior when hovering over options.
	- Introduced a new configurable setting that allows users to control whether the input remains focused during option hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->