### PR TITLE
Fix clear button position

### DIFF
--- a/src/components/VvCombobox/VvCombobox.vue
+++ b/src/components/VvCombobox/VvCombobox.vue
@@ -425,36 +425,22 @@ export default {
 </script>
 
 <template>
-    <div
-        v-if="!native"
-        :id="hasId"
-        :class="bemCssClasses"
-    >
-        <label
-            v-if="label"
-            :id="hasLabelId"
-            :for="propsDefaults.searchable ? hasSearchId : undefined"
-        >
+    <div v-if="!native" :id="hasId" :class="bemCssClasses">
+        <label v-if="label" :id="hasLabelId" :for="propsDefaults.searchable ? hasSearchId : undefined">
             {{ label }}
         </label>
         <div ref="wrapperEl" class="vv-select__wrapper">
             <VvDropdown
-                ref="dropdownEl"
-                v-model="expanded"
-                v-bind="dropdownProps"
-                :role="DropdownRole.listbox"
-                @after-expand="onAfterExpand"
-                @after-collapse="onAfterCollapse"
+                ref="dropdownEl" v-model="expanded" v-bind="dropdownProps" :role="DropdownRole.listbox"
+                @after-expand="onAfterExpand" @after-collapse="onAfterCollapse"
             >
-                <template
-                    v-if="propsDefaults.searchable || $slots['dropdown::before']"
-                    #before
-                >
+                <template v-if="propsDefaults.searchable || $slots['dropdown::before']" #before>
                     <!-- @slot Slot before dropdown items -->
                     <slot name="dropdown::before" />
                     <input
                         v-if="propsDefaults.searchable && !disabled"
-                        :id="hasSearchId" ref="inputSearchEl"
+                        :id="hasSearchId"
+                        ref="inputSearchEl"
                         v-model="searchText"
                         aria-autocomplete="list"
                         :aria-controls="hasDropdownId"
@@ -477,15 +463,10 @@ export default {
                             class="vv-select__icon"
                         />
                         <div
-                            ref="inputEl" v-bind="aria"
-                            class="vv-select__input"
-                            role="combobox"
-                            :aria-controls="hasDropdownId"
-                            :aria-expanded="expanded"
-                            :aria-labelledby="hasLabelId"
+                            ref="inputEl" v-bind="aria" class="vv-select__input" role="combobox"
+                            :aria-controls="hasDropdownId" :aria-expanded="expanded" :aria-labelledby="hasLabelId"
                             :aria-describedby="hasHintLabelOrSlot ? hasHintId : undefined"
-                            :aria-errormessage="hasInvalidLabelOrSlot ? hasHintId : undefined"
-                            :tabindex="hasTabindex"
+                            :aria-errormessage="hasInvalidLabelOrSlot ? hasHintId : undefined" :tabindex="hasTabindex"
                             @click.passive="onClickInput"
                         >
                             <!-- @slot Slot for value customization -->
@@ -495,17 +476,13 @@ export default {
                                         {{ hasValue }}
                                     </div>
                                     <VvBadge
-                                        v-for="(option, index) in selectedOptions"
-                                        v-else :key="index"
-                                        :modifiers="badgeModifiers"
-                                        class="vv-select__badge"
+                                        v-for="(option, index) in selectedOptions" v-else :key="index"
+                                        :modifiers="badgeModifiers" class="vv-select__badge"
                                     >
                                         {{ getOptionLabel(option) }}
                                         <button
-                                            v-if="isUnselectable"
-                                            :aria-label="propsDefaults.deselectActionLabel"
-                                            type="button"
-                                            @click.stop="onInput(option)"
+                                            v-if="isUnselectable" :aria-label="propsDefaults.deselectActionLabel"
+                                            type="button" @click.stop="onInput(option)"
                                         >
                                             <VvIcon name="close" />
                                         </button>
@@ -516,19 +493,20 @@ export default {
                                 </template>
                             </slot>
                         </div>
-                        <VvInputClearAction
-                            v-if="isUnselectable"
-                            input-type="select"
-                            :label="labelClear"
-                            :icon="iconClear"
-                            @clear="onClear"
-                        />
                         <VvIcon
                             v-if="hasIconAfter"
                             v-bind="hasIconAfter"
                             class="vv-select__icon vv-select__icon-after"
                         />
                     </div>
+                    <VvInputClearAction
+                        v-if="isUnselectable"
+                        input-type="select"
+                        :label="labelClear"
+                        :icon="iconClear"
+                        :disabled="!isDirty"
+                        @clear="onClear"
+                    />
                     <div v-if="$slots.after" class="vv-select__input-after">
                         <!-- @slot Slot after input -->
                         <slot name="after" v-bind="slotProps" />
@@ -552,7 +530,10 @@ export default {
                                             propsDefaults.selectHintLabel,
                                         selectedHintLabel:
                                             propsDefaults.selectedHintLabel,
-                                    }" :key="i" class="vv-dropdown-option" :focus-on-hover="focusOnHover"
+                                        focusOnHover,
+                                    }"
+                                    :key="i"
+                                    class="vv-dropdown-option"
                                     @click.passive="onInput(item)"
                                 >
                                     <!-- @slot Slot for option customization -->
@@ -569,8 +550,7 @@ export default {
                                 </VvDropdownOption>
                             </template>
                             <VvDropdownOption
-                                v-else
-                                v-bind="{
+                                v-else v-bind="{
                                     selected: isOptionSelected(option),
                                     disabled: isOptionDisabledOrNotSelectable(option),
                                     unselectable: isUnselectable,
@@ -580,15 +560,13 @@ export default {
                                         propsDefaults.selectHintLabel,
                                     selectedHintLabel:
                                         propsDefaults.selectedHintLabel,
-                                }"
-                                class="vv-dropdown-option"
-                                :focus-on-hover="focusOnHover"
+                                    focusOnHover,
+                                }" class="vv-dropdown-option"
                                 @click.passive="onInput(option)"
                             >
                                 <!-- @slot Slot for option customization -->
                                 <slot
-                                    name="option"
-                                    v-bind="{
+                                    name="option" v-bind="{
                                         option,
                                         selectedOptions,
                                         selected: isOptionSelected(option),
@@ -642,9 +620,5 @@ export default {
             </template>
         </HintSlot>
     </div>
-    <VvSelect
-        v-else
-        v-bind="selectProps"
-        @update:model-value="emit('update:modelValue', $event)"
-    />
+    <VvSelect v-else v-bind="selectProps" @update:model-value="emit('update:modelValue', $event)" />
 </template>

--- a/src/components/VvInputText/VvInputText.vue
+++ b/src/components/VvInputText/VvInputText.vue
@@ -557,14 +557,17 @@ const {
 const PasswordInputActions = VvInputTextActionsFactory(
     INPUT_TYPES.PASSWORD,
     props,
+    isDirty,
 )
 const NumberInputActions = VvInputTextActionsFactory(
     INPUT_TYPES.NUMBER,
     props,
+    isDirty,
 )
 const SearchInputActions = VvInputTextActionsFactory(
     INPUT_TYPES.SEARCH,
     props,
+    isDirty,
 )
 
 // auto-width

--- a/src/components/VvInputText/VvInputTextActions.ts
+++ b/src/components/VvInputText/VvInputTextActions.ts
@@ -1,4 +1,4 @@
-import type { Component } from 'vue'
+import type { Component, Ref } from 'vue'
 import type { VvInputTextPropsTypes } from '.'
 import { INPUT_TYPES } from '.'
 import VvInputClearAction from '../common/VvInputClearAction'

--- a/src/components/VvInputText/VvInputTextActions.ts
+++ b/src/components/VvInputText/VvInputTextActions.ts
@@ -9,6 +9,7 @@ import VvIcon from '../VvIcon/VvIcon.vue'
 export default function VvInputTextActionsFactory(
     type: typeof INPUT_TYPES[keyof typeof INPUT_TYPES],
     parentProps: VvInputTextPropsTypes,
+    isDirty: Ref<boolean>,
 ): Component {
     return {
         name: 'VvInputTextActions',
@@ -24,6 +25,7 @@ export default function VvInputTextActionsFactory(
             })
 
             return {
+                isDirty,
                 isDisabled,
                 labelStepUp: parentProps.labelStepUp,
                 labelStepDown: parentProps.labelStepDown,
@@ -41,7 +43,7 @@ export default function VvInputTextActionsFactory(
                     const { onClear } = this.$attrs
                     actions = [
                         h(VvInputClearAction, {
-                            disabled: this.isDisabled,
+                            disabled: this.isDisabled || !this.isDirty,
                             label: this.labelClear,
                             onClear,
                         }),

--- a/src/components/VvSelect/VvSelect.vue
+++ b/src/components/VvSelect/VvSelect.vue
@@ -239,12 +239,16 @@ export default {
                         </optgroup>
                     </template>
                 </select>
-                <VvInputClearAction
-                    v-if="isUnselectable" input-type="select" :label="labelClear" :icon="iconClear"
-                    @clear="onClear"
-                />
                 <VvIcon v-if="hasIconAfter" v-bind="hasIconAfter" class="vv-select__icon vv-select__icon-after" />
             </div>
+            <VvInputClearAction
+                v-if="isUnselectable"
+                input-type="select"
+                :label="labelClear"
+                :icon="iconClear"
+                :disabled="!isDirty"
+                @clear="onClear"
+            />
             <div v-if="$slots.after" class="vv-select__input-after">
                 <!-- @slot Slot after input -->
                 <slot name="after" v-bind="slotProps" />


### PR DESCRIPTION
fix: clear button position for `VvCombobox` and `VvCombobox
fix: disable clear icon for all components when the input is not dirty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved template formatting and code compactness in combobox and select components for better readability and consistency.

- **New Features**
  - The clear action button in input, combobox, and select components is now disabled when there is no value to clear, providing clearer feedback to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->