### PR TITLE
Fix wildcard `*` for `VvInputFile` accept prop

### DIFF
--- a/src/utils/FileUtilities.ts
+++ b/src/utils/FileUtilities.ts
@@ -38,7 +38,7 @@ function acceptedMimeTypes(acceptValue?: string) {
  */
 export function validateFileList(fileList: FileList, acceptValue?: string): boolean {
     // If there are no restrictions, accept any file
-    if (!acceptValue || acceptValue.trim() === '') {
+    if (!acceptValue || acceptValue.trim() === '' || acceptValue === '*') {
         return true
     }
 
@@ -77,7 +77,7 @@ export function validateFileList(fileList: FileList, acceptValue?: string): bool
  */
 export function filterFileList(fileList: FileList, acceptValue?: string): File[] {
     // If there are no restrictions, return all files
-    if (!acceptValue || acceptValue.trim() === '') {
+    if (!acceptValue || acceptValue.trim() === '' || acceptValue === '*') {
         return Array.from(fileList)
     }
 


### PR DESCRIPTION
fix: handle wildcard `*` for `VvInputFile` accept prop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file selection to allow all file types when the accept attribute is set to "*", ensuring consistent behavior with unrestricted file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->