### PR TITLE
Fix disabled state on `disableKey` selection in `VvCheckBoxGroup` and…

### DIFF
--- a/src/components/VvCheckboxGroup/VvCheckboxGroup.vue
+++ b/src/components/VvCheckboxGroup/VvCheckboxGroup.vue
@@ -34,7 +34,7 @@ useGroupStateProvide<InputGroupState>(INJECTION_KEY_CHECK_GROUP, {
 })
 
 // options
-const { getOptionLabel, getOptionValue } = useOptions(props)
+const { getOptionLabel, getOptionValue, isOptionDisabled } = useOptions(props)
 
 // stypes
 const bemCssClasses = useModifiers(
@@ -58,6 +58,7 @@ function getOptionProps(option: string | Option, index: number) {
         label: getOptionLabel(option),
         value: getOptionValue(option),
         required: props.required,
+        disabled: isOptionDisabled(option),
     }
 }
 const { HintSlot, hintSlotScope } = HintSlotFactory(propsDefaults, slots)

--- a/src/components/VvRadioGroup/VvRadioGroup.vue
+++ b/src/components/VvRadioGroup/VvRadioGroup.vue
@@ -34,7 +34,7 @@ useGroupStateProvide<InputGroupState>(INJECTION_KEY_RADIO_GROUP, {
 })
 
 // options
-const { getOptionLabel, getOptionValue } = useOptions(props)
+const { getOptionLabel, getOptionValue, isOptionDisabled } = useOptions(props)
 
 // styles
 const bemCssClasses = useModifiers(
@@ -58,6 +58,7 @@ function getOptionProps(option: string | Option, index: number) {
         label: getOptionLabel(option),
         value: getOptionValue(option),
         required: props.required,
+        disabled: isOptionDisabled(option),
     }
 }
 


### PR DESCRIPTION
Fix disabled state on `disableKey` selection in `VvCheckBoxGroup` and `VvRadioGroup`

fix: fix disabled state on `disableKey` selection in `VvCheckBoxGroup` and `VvRadioGroup`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for disabling individual options within checkbox and radio groups. Each option can now be conditionally disabled based on specific logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->