### PR TITLE
Remove rollupOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -427,7 +427,7 @@
     "@tsconfig/node18": "^18.2.4",
     "@types/jest-axe": "^3.5.9",
     "@types/jsdom": "^21.1.7",
-    "@types/node": "^24.5.0",
+    "@types/node": "^24.5.1",
     "@types/pica": "^9.0.5",
     "@types/yargs": "^17.0.33",
     "@vitejs/plugin-vue": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: 5.3.0
-        version: 5.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0)(typescript@5.9.2)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@24.5.0)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+        version: 5.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0)(typescript@5.9.2)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       '@babel/core':
         specifier: ^7.28.4
         version: 7.28.4
@@ -68,25 +68,25 @@ importers:
         version: 3.0.2
       '@nabla/vite-plugin-eslint':
         specifier: ^2.0.6
-        version: 2.0.6(eslint@9.35.0)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+        version: 2.0.6(eslint@9.35.0)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       '@storybook/addon-a11y':
         specifier: ^9.1.6
-        version: 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
+        version: 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
       '@storybook/addon-docs':
         specifier: ^9.1.6
-        version: 9.1.6(@types/react@18.3.12)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
+        version: 9.1.6(@types/react@18.3.12)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
       '@storybook/addon-links':
         specifier: ^9.1.6
-        version: 9.1.6(react@18.3.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
+        version: 9.1.6(react@18.3.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
       '@storybook/cli':
         specifier: ^9.1.6
-        version: 9.1.6(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+        version: 9.1.6(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       '@storybook/test-runner':
         specifier: ^0.23.0
-        version: 0.23.0(@types/node@24.5.0)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+        version: 0.23.0(@types/node@24.5.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
       '@storybook/vue3-vite':
         specifier: ^9.1.6
-        version: 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
+        version: 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
       '@tsconfig/node18':
         specifier: ^18.2.4
         version: 18.2.4
@@ -97,8 +97,8 @@ importers:
         specifier: ^21.1.7
         version: 21.1.7
       '@types/node':
-        specifier: ^24.5.0
-        version: 24.5.0
+        specifier: ^24.5.1
+        version: 24.5.1
       '@types/pica':
         specifier: ^9.0.5
         version: 9.0.5
@@ -107,7 +107,7 @@ importers:
         version: 17.0.33
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
+        version: 6.0.1(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
       '@volverjs/style':
         specifier: ^0.1.22
         version: 0.1.22
@@ -155,7 +155,7 @@ importers:
         version: 1.92.1
       storybook:
         specifier: ^9.1.6
-        version: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+        version: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       storybook-addon-markdown-docs:
         specifier: ^2.0.0
         version: 2.0.0
@@ -164,7 +164,7 @@ importers:
         version: 5.44.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2)
+        version: 10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2)
       typescript:
         specifier: ~5.9.2
         version: 5.9.2
@@ -176,10 +176,10 @@ importers:
         version: 29.0.0(@babel/parser@7.28.4)(vue@3.5.21(typescript@5.9.2))
       vite:
         specifier: ^7.1.5
-        version: 7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+        version: 7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
       vite-plugin-externalize-deps:
         specifier: ^0.9.0
-        version: 0.9.0(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+        version: 0.9.0(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       vue:
         specifier: ^3.5.21
         version: 3.5.21(typescript@5.9.2)
@@ -1986,8 +1986,8 @@ packages:
   '@types/node@14.18.63':
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
 
-  '@types/node@24.5.0':
-    resolution: {integrity: sha512-y1dMvuvJspJiPSDZUQ+WMBvF7dpnEqN4x9DDC9ie5Fs/HUZJA3wFp7EhHoVaKX/iI0cRoECV8X2jL8zi0xrHCg==}
+  '@types/node@24.5.1':
+    resolution: {integrity: sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==}
 
   '@types/parse5@5.0.3':
     resolution: {integrity: sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==}
@@ -6723,16 +6723,16 @@ snapshots:
 
   '@adobe/css-tools@4.4.1': {}
 
-  '@antfu/eslint-config@5.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0)(typescript@5.9.2)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@24.5.0)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@antfu/eslint-config@5.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0)(typescript@5.9.2)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 0.11.0
       '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.35.0)
       '@eslint/markdown': 7.2.0
       '@stylistic/eslint-plugin': 5.3.1(eslint@9.35.0)
-      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0)(typescript@5.9.2))(eslint@9.35.0)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.36.0(eslint@9.35.0)(typescript@5.9.2))(eslint@9.35.0)(typescript@5.9.2)
       '@typescript-eslint/parser': 8.44.0(eslint@9.35.0)(typescript@5.9.2)
-      '@vitest/eslint-plugin': 1.3.10(eslint@9.35.0)(typescript@5.9.2)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@24.5.0)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      '@vitest/eslint-plugin': 1.3.10(eslint@9.35.0)(typescript@5.9.2)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       ansis: 4.1.0
       cac: 6.7.14
       eslint: 9.35.0
@@ -8083,27 +8083,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+      jest-config: 29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -8132,7 +8132,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -8150,7 +8150,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -8172,7 +8172,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.29
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -8242,7 +8242,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -8376,13 +8376,13 @@ snapshots:
 
   '@mdx-js/util@1.6.22': {}
 
-  '@nabla/vite-plugin-eslint@2.0.6(eslint@9.35.0)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@nabla/vite-plugin-eslint@2.0.6(eslint@9.35.0)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@types/eslint': 9.6.1
       chalk: 4.1.2
       debug: 4.4.1
       eslint: 9.35.0
-      vite: 7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8556,48 +8556,48 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@storybook/addon-a11y@9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))':
+  '@storybook/addon-a11y@9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.2
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
 
-  '@storybook/addon-docs@9.1.6(@types/react@18.3.12)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))':
+  '@storybook/addon-docs@9.1.6(@types/react@18.3.12)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@18.3.12)(react@18.3.1)
-      '@storybook/csf-plugin': 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
+      '@storybook/csf-plugin': 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
       '@storybook/icons': 1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 9.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
+      '@storybook/react-dom-shim': 9.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-links@9.1.6(react@18.3.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))':
+  '@storybook/addon-links@9.1.6(react@18.3.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
     optionalDependencies:
       react: 18.3.1
 
-  '@storybook/builder-vite@9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@storybook/builder-vite@9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      '@storybook/csf-plugin': 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       ts-dedent: 2.2.0
-      vite: 7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
 
-  '@storybook/cli@9.1.6(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@storybook/cli@9.1.6(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
-      '@storybook/codemod': 9.1.6(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@testing-library/dom@10.4.0)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      '@storybook/codemod': 9.1.6(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@testing-library/dom@10.4.0)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       '@types/semver': 7.5.8
       commander: 12.1.0
       create-storybook: 9.1.6
       giget: 1.2.3
       jscodeshift: 0.15.2(@babel/preset-env@7.28.3(@babel/core@7.28.4))
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@babel/preset-env'
@@ -8609,7 +8609,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@storybook/codemod@9.1.6(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@testing-library/dom@10.4.0)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@storybook/codemod@9.1.6(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@testing-library/dom@10.4.0)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.6
@@ -8617,7 +8617,7 @@ snapshots:
       globby: 14.0.2
       jscodeshift: 0.15.2(@babel/preset-env@7.28.3(@babel/core@7.28.4))
       prettier: 3.6.2
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
       - '@babel/preset-env'
@@ -8628,9 +8628,9 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@storybook/csf-plugin@9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))':
+  '@storybook/csf-plugin@9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))':
     dependencies:
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -8640,13 +8640,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-dom-shim@9.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))':
+  '@storybook/react-dom-shim@9.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
 
-  '@storybook/test-runner@0.23.0(@types/node@24.5.0)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))':
+  '@storybook/test-runner@0.23.0(@types/node@24.5.1)(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/generator': 7.27.3
@@ -8656,17 +8656,17 @@ snapshots:
       '@swc/core': 1.9.2
       '@swc/jest': 0.2.37(@swc/core@1.9.2)
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+      jest: 29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
-      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2)))
+      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2)))
       jest-runner: 29.7.0
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2)))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2)))
       nyc: 15.1.0
       playwright: 1.49.0
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@swc/helpers'
       - '@types/node'
@@ -8676,24 +8676,24 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@storybook/vue3-vite@9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
+  '@storybook/vue3-vite@9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
     dependencies:
-      '@storybook/builder-vite': 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
-      '@storybook/vue3': 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vue@3.5.21(typescript@5.9.2))
+      '@storybook/builder-vite': 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      '@storybook/vue3': 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vue@3.5.21(typescript@5.9.2))
       find-package-json: 1.2.0
       magic-string: 0.30.17
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       typescript: 5.9.2
-      vite: 7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
       vue-component-meta: 2.1.10(typescript@5.9.2)
       vue-docgen-api: 4.79.2(vue@3.5.21(typescript@5.9.2))
     transitivePeerDependencies:
       - vue
 
-  '@storybook/vue3@9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vue@3.5.21(typescript@5.9.2))':
+  '@storybook/vue3@9.1.6(storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)))(vue@3.5.21(typescript@5.9.2))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      storybook: 9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       type-fest: 2.19.0
       vue: 3.5.21(typescript@5.9.2)
       vue-component-type-helpers: 3.0.7
@@ -8833,7 +8833,7 @@ snapshots:
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
 
   '@types/debug@4.1.12':
     dependencies:
@@ -8850,7 +8850,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
 
   '@types/hast@2.3.10':
     dependencies:
@@ -8878,7 +8878,7 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       '@types/tough-cookie': 4.0.5
       parse5: 7.2.1
 
@@ -8898,7 +8898,7 @@ snapshots:
 
   '@types/node@14.18.63': {}
 
-  '@types/node@24.5.0':
+  '@types/node@24.5.1':
     dependencies:
       undici-types: 7.12.0
 
@@ -8921,7 +8921,7 @@ snapshots:
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       minipass: 4.2.8
 
   '@types/tough-cookie@4.0.5': {}
@@ -8934,7 +8934,7 @@ snapshots:
 
   '@types/wait-on@5.3.4':
     dependencies:
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
 
   '@types/web-bluetooth@0.0.21': {}
 
@@ -8946,7 +8946,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.35.0)(typescript@5.9.2))(eslint@9.35.0)(typescript@5.9.2)':
@@ -8966,10 +8966,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0)(typescript@5.9.2))(eslint@9.35.0)(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.36.0(eslint@9.35.0)(typescript@5.9.2))(eslint@9.35.0)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.44.0(eslint@9.35.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.36.0(eslint@9.35.0)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.44.0
       '@typescript-eslint/type-utils': 8.44.0(eslint@9.35.0)(typescript@5.9.2)
       '@typescript-eslint/utils': 8.44.0(eslint@9.35.0)(typescript@5.9.2)
@@ -9134,20 +9134,20 @@ snapshots:
       '@typescript-eslint/types': 8.44.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-vue@6.0.1(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
       vue: 3.5.21(typescript@5.9.2)
 
-  '@vitest/eslint-plugin@1.3.10(eslint@9.35.0)(typescript@5.9.2)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@24.5.0)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@vitest/eslint-plugin@1.3.10(eslint@9.35.0)(typescript@5.9.2)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.44.0
       '@typescript-eslint/utils': 8.36.0(eslint@9.35.0)(typescript@5.9.2)
       eslint: 9.35.0
     optionalDependencies:
       typescript: 5.9.2
-      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@24.5.0)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9167,22 +9167,22 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(vite@6.3.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@vitest/mocker@3.0.5(vite@6.3.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.3.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
     optional: true
 
-  '@vitest/mocker@3.2.4(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.0.5':
     dependencies:
@@ -9925,13 +9925,13 @@ snapshots:
 
   core-js-pure@3.39.0: {}
 
-  create-jest@29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2)):
+  create-jest@29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+      jest-config: 29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10502,7 +10502,7 @@ snapshots:
     dependencies:
       eslint: 9.35.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0)(typescript@5.9.2))(eslint@9.35.0)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.36.0(eslint@9.35.0)(typescript@5.9.2))(eslint@9.35.0)(typescript@5.9.2)
 
   eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.36.0(eslint@9.35.0)(typescript@5.9.2))(eslint@9.35.0)(vue-eslint-parser@10.2.0(eslint@9.35.0)):
     dependencies:
@@ -11456,7 +11456,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -11476,16 +11476,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2)):
+  jest-cli@29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+      create-jest: 29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+      jest-config: 29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -11495,7 +11495,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2)):
+  jest-config@29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2)):
     dependencies:
       '@babel/core': 7.28.4
       '@jest/test-sequencer': 29.7.0
@@ -11520,8 +11520,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 24.5.0
-      ts-node: 10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2)
+      '@types/node': 24.5.1
+      ts-node: 10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -11550,7 +11550,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -11560,7 +11560,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -11613,13 +11613,13 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       jest-util: 29.7.0
 
-  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))):
+  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+      jest: 29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -11680,7 +11680,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -11708,7 +11708,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -11758,7 +11758,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -11773,11 +11773,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.3.0
-      jest: 29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+      jest: 29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -11788,7 +11788,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -11797,17 +11797,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2)):
+  jest@29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.5.0)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2))
+      jest-cli: 29.7.0(@types/node@24.5.1)(ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -13693,13 +13693,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)):
+  storybook@9.1.6(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.3
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.1
@@ -13960,14 +13960,14 @@ snapshots:
 
   ts-map@1.0.3: {}
 
-  ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.0)(typescript@5.9.2):
+  ts-node@10.9.2(@swc/core@1.9.2)(@types/node@24.5.1)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -14304,13 +14304,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.0.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1):
+  vite-node@3.0.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.3.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14326,11 +14326,11 @@ snapshots:
       - yaml
     optional: true
 
-  vite-plugin-externalize-deps@0.9.0(vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)):
+  vite-plugin-externalize-deps@0.9.0(vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
-      vite: 7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
 
-  vite@6.3.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1):
+  vite@6.3.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.1
       fdir: 6.5.0(picomatch@4.0.3)
@@ -14339,7 +14339,7 @@ snapshots:
       rollup: 4.50.2
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       fsevents: 2.3.3
       sass: 1.92.1
       sass-embedded: 1.92.1
@@ -14347,7 +14347,7 @@ snapshots:
       yaml: 2.8.1
     optional: true
 
-  vite@7.1.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1):
+  vite@7.1.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.1
       fdir: 6.5.0(picomatch@4.0.3)
@@ -14356,17 +14356,17 @@ snapshots:
       rollup: 4.50.2
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       fsevents: 2.3.3
       sass: 1.92.1
       sass-embedded: 1.92.1
       terser: 5.44.0
       yaml: 2.8.1
 
-  vitest@3.0.5(@types/debug@4.1.12)(@types/node@24.5.0)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1):
+  vitest@3.0.5(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@27.0.0(postcss@8.5.6))(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(vite@6.3.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.0.5(vite@6.3.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.0.5
       '@vitest/snapshot': 3.0.5
@@ -14382,12 +14382,12 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-node: 3.0.5(@types/node@24.5.0)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.3.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
+      vite-node: 3.0.5(@types/node@24.5.1)(sass-embedded@1.92.1)(sass@1.92.1)(terser@5.44.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 24.5.0
+      '@types/node': 24.5.1
       jsdom: 27.0.0(postcss@8.5.6)
     transitivePeerDependencies:
       - jiti

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -51,30 +51,6 @@ const baseConfig = {
             '@': fileURLToPath(new URL('../src', import.meta.url)),
         },
     },
-    build: {
-        rollupOptions: {
-            external: ['node:fs', 'node:path', 'yargs', 'yargs/helpers', 'vue', '@vueuse/core', 'dot-prop', 'mitt', 'vue-imask', '@floating-ui/vue', '@iconify/vue', '@iconify/tools', '@iconify/utils', 'chokidar','comlink'],
-            output: {
-                globals: {
-                    vue: 'Vue',
-                    '@vueuse/core': 'VueUse',
-                    'dot-prop': 'dotProp',
-                    mitt: 'mitt',
-                    'vue-imask': 'VueImask',
-                    '@floating-ui/vue': 'FloatingVue',
-                    '@iconify/vue': 'Iconify',
-                    comlink: 'Comlink',
-                    'node:fs': 'fs',
-                    'node:path': 'path',
-                    yargs: 'yargs',
-                    'yargs/helpers': 'yargsHelpers',
-                    '@iconify/tools': 'IconifyTools',
-                    '@iconify/utils': 'IconifyUtils',
-                    chokidar: 'chokidar',
-                },
-            },
-        },
-    }
 }
 
 // build library
@@ -87,7 +63,6 @@ packageJson.typesVersions['*']['*'] = ['dist/index.d.ts']
 build({
     ...baseConfig,
     build: {
-        ...baseConfig.build,
         watch,
         minify,
         emptyOutDir: false,
@@ -111,7 +86,6 @@ packageJson.typesVersions['*']['resolvers/unplugin'] = [
 build({
     ...baseConfig,
     build: {
-        ...baseConfig.build,
         watch,
         minify,
         emptyOutDir: false,
@@ -133,7 +107,6 @@ packageJson.typesVersions['*'].icons = ['dist/icons.d.ts']
 build({
     configFile: false,
     build: {
-        ...baseConfig.build,
         watch,
         minify,
         emptyOutDir: false,
@@ -147,7 +120,6 @@ build({
 build({
     configFile: false,
     build: {
-        ...baseConfig.build,
         watch,
         minify,
         emptyOutDir: false,
@@ -171,7 +143,6 @@ packageJson.typesVersions['*'].directives = ['dist/directives/index.d.ts']
 build({
     ...baseConfig,
     build: {
-        ...baseConfig.build,
         watch,
         minify,
         emptyOutDir: false,
@@ -207,7 +178,6 @@ directivesSources.forEach(({ name, entry }) => {
     build({
         ...baseConfig,
         build: {
-            ...baseConfig.build,
             watch: hot ? {} : undefined,
             minify,
             lib: {
@@ -230,7 +200,6 @@ packageJson.typesVersions['*'].composables = ['dist/composables/index.d.ts']
 build({
     ...baseConfig,
     build: {
-        ...baseConfig.build,
         watch,
         minify,
         emptyOutDir: false,
@@ -252,7 +221,6 @@ packageJson.typesVersions['*'].components = ['dist/components/index.d.ts']
 build({
     ...baseConfig,
     build: {
-        ...baseConfig.build,
         watch,
         minify,
         emptyOutDir: false,
@@ -288,7 +256,6 @@ componentsSources.forEach(({ name, entry }) => {
     build({
         ...baseConfig,
         build: {
-            ...baseConfig.build,
             watch: hot ? {} : undefined,
             minify,
             lib: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,28 +12,6 @@ export default ({ mode }: { mode: string }) => {
                 name: '@volverjs/ui-vue',
                 entry: path.resolve(__dirname, 'src/index.ts'),
             },
-            rollupOptions: {
-                external: ['node:fs', 'node:path', 'yargs', 'yargs/helpers', 'vue', '@vueuse/core', 'dot-prop', 'mitt', 'vue-imask', '@floating-ui/vue', '@iconify/vue', '@iconify/tools', '@iconify/utils', 'chokidar', 'comlink'],
-                output: {
-                    globals: {
-                        'vue': 'Vue',
-                        '@vueuse/core': 'VueUse',
-                        'dot-prop': 'dotProp',
-                        'mitt': 'mitt',
-                        'vue-imask': 'VueImask',
-                        '@floating-ui/vue': 'FloatingVue',
-                        '@iconify/vue': 'Iconify',
-                        'comlink': 'Comlink',
-                        'node:fs': 'fs',
-                        'node:path': 'path',
-                        'yargs': 'yargs',
-                        'yargs/helpers': 'yargsHelpers',
-                        '@iconify/tools': 'IconifyTools',
-                        '@iconify/utils': 'IconifyUtils',
-                        'chokidar': 'chokidar',
-                    },
-                },
-            },
         },
         base: mode === 'development' ? './' : '/ui-vue/',
         plugins: [


### PR DESCRIPTION
fix: remove `rollupOptions` from `vite.configt.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Updated build configuration to include previously external dependencies in distributed bundles and removed reliance on external globals. This may affect bundle size and consumption setup, with no changes to the public API.

* Chores
  * Bumped a development dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->