### PR TITLE
Move `@iconify/utils` into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -398,6 +398,7 @@
   "dependencies": {
     "@floating-ui/vue": "^1.1.9",
     "@iconify/tools": "^5.0.2",
+    "@iconify/utils": "^3.1.0",
     "@iconify/vue": "^5.0.0",
     "blurhash": "^2.0.5",
     "chokidar": "^5.0.0",
@@ -416,7 +417,6 @@
     "@babel/preset-env": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
     "@iconify/types": "^2.0.0",
-    "@iconify/utils": "^3.1.0",
     "@nabla/vite-plugin-eslint": "^2.0.6",
     "@storybook/addon-a11y": "^10.1.11",
     "@storybook/addon-docs": "^10.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@iconify/tools':
         specifier: ^5.0.2
         version: 5.0.2
+      '@iconify/utils':
+        specifier: ^3.1.0
+        version: 3.1.0
       '@iconify/vue':
         specifier: ^5.0.0
         version: 5.0.0(vue@3.5.26(typescript@5.9.3))
@@ -63,9 +66,6 @@ importers:
       '@iconify/types':
         specifier: ^2.0.0
         version: 2.0.0
-      '@iconify/utils':
-        specifier: ^3.1.0
-        version: 3.1.0
       '@nabla/vite-plugin-eslint':
         specifier: ^2.0.6
         version: 2.0.6(eslint@9.39.2)(vite@7.3.1(@types/node@25.0.3)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management: promoted `@iconify/utils` from development-only to runtime dependency to ensure required icon utilities are available during application execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->