### PR TITLE
Fix `undici` error

### DIFF
--- a/package.json
+++ b/package.json
@@ -408,19 +408,20 @@
   },
   "dependencies": {
     "@floating-ui/vue": "^1.1.10",
-    "@iconify/tools": "^5.0.3",
-    "@iconify/utils": "^3.1.0",
     "@iconify/vue": "^5.0.0",
     "@tanstack/vue-virtual": "^3.13.18",
     "blurhash": "^2.0.5",
-    "chokidar": "^5.0.0",
     "comlink": "^4.4.2",
     "dot-prop": "^10.1.0",
-    "jsdom": "^28.1.0",
     "mitt": "^3.0.1",
     "pica": "^9.0.1",
     "vue-imask": "^7.6.1",
-    "vuedraggable": "^4.1.0",
+    "vuedraggable": "^4.1.0"
+  },
+  "optionalDependencies": {
+    "@iconify/tools": "^5.0.3",
+    "@iconify/utils": "^3.1.0",
+    "chokidar": "^5.0.0",
     "yargs": "^18.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -422,6 +422,7 @@
     "@iconify/tools": "^5.0.3",
     "@iconify/utils": "^3.1.0",
     "chokidar": "^5.0.0",
+    "jsdom": "^28.1.0",
     "yargs": "^18.0.0"
   },
   "devDependencies": {
@@ -459,7 +460,6 @@
     "eslint": "^9.39.2",
     "glob": "^13.0.6",
     "jest-axe": "^10.0.0",
-    "jsdom": "^28.1.0",
     "npm-run-all": "^4.1.5",
     "playwright": "^1.58.2",
     "prettier": "^3.8.1",

--- a/src/components/VvIcon/VvIcon.vue
+++ b/src/components/VvIcon/VvIcon.vue
@@ -70,7 +70,14 @@ function getSvgContent(svg: string): SVGSVGElement | undefined {
             // jsdom not available, SVG parsing will be skipped in SSR
         }
     }
-    const domParser = dom ? new dom.DOMParser() : new window.DOMParser()
+    const domParser = dom
+        ? new dom.DOMParser()
+        : typeof window !== 'undefined'
+            ? new window.DOMParser()
+            : null
+    if (!domParser) {
+        return undefined
+    }
     const svgDomString = domParser.parseFromString(svg, 'text/html')
     const svgEl = svgDomString.querySelector('svg')
     return svgEl

--- a/src/components/VvIcon/VvIcon.vue
+++ b/src/components/VvIcon/VvIcon.vue
@@ -62,9 +62,13 @@ function getSvgContent(svg: string): SVGSVGElement | undefined {
     let dom
     if (typeof window === 'undefined') {
         // SSR
-        // eslint-disable-next-line ts/no-require-imports
-        const { JSDOM } = require('jsdom')
-        dom = new JSDOM().window
+        try {
+            // eslint-disable-next-line ts/no-require-imports
+            const { JSDOM } = require('jsdom')
+            dom = new JSDOM().window
+        } catch {
+            // jsdom not available, SVG parsing will be skipped in SSR
+        }
     }
     const domParser = dom ? new dom.DOMParser() : new window.DOMParser()
     const svgDomString = domParser.parseFromString(svg, 'text/html')


### PR DESCRIPTION
fix: move node dependencies into `optionalDependencies`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced required install footprint by moving several non-essential runtime packages to optional, and added an extra optional CLI helper.

* **Bug Fixes**
  * Improved server-side rendering resilience by skipping optional parsing when optional packages are unavailable, avoiding runtime failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->