### PR TITLE
fix(build): preserve type declarations in published package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.13] - 2026-04-08
+## [0.0.14] - 2026-06-16
+
+### Fixed
+
+- TypeScript declarations (`.d.ts`) were missing from the published package. The `dist` clean step introduced in `0.0.13` ran inside `scripts/build.js`, _after_ `generate-tsd` had emitted the declarations, deleting them before the Vite bundles were generated. Cleaning now runs as a separate `clean` step before `generate-tsd`, so declarations are preserved (fixes `Could not find a declaration file for module '@volverjs/ui-vue/...'`).
+
+## [0.0.13] - 2026-06-16
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -400,7 +400,8 @@
   "scripts": {
     "dev": "storybook dev -p 6006",
     "styleguide": "storybook build",
-    "build": "npm run generate-icons && npm run generate-tsd && node ./scripts/build.js",
+    "build": "npm run clean && npm run generate-icons && npm run generate-tsd && node ./scripts/build.js",
+    "clean": "node ./scripts/clean.js",
     "hot": "node ./scripts/build.js --hot",
     "type-check": "vue-tsc --noEmit",
     "lint": "eslint .",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -12,11 +12,11 @@ const hot = process.argv.includes('--hot')
 const watch = hot ? {} : undefined
 const minify = hot ? false : 'esbuild'
 
-// clean the output directory once before the (parallel) builds run,
-// since every build() below uses `emptyOutDir: false`
-if (!hot) {
-    fs.rmSync('./dist', { recursive: true, force: true })
-}
+// NOTE: do NOT clean ./dist here. `generate-tsd` runs before this script and
+// emits the .d.ts declarations into ./dist; wiping the directory at this point
+// would delete them (every build() below uses `emptyOutDir: false`, so the .js
+// bundles are added alongside the declarations). The clean step runs as a
+// separate `clean` npm script before `generate-tsd` instead.
 
 // load package.json and reset exports
 const packageJson = JSON.parse(fs.readFileSync('./package.json'))

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -1,0 +1,6 @@
+import fs from 'node:fs'
+
+// Clean the output directory before the build pipeline runs.
+// This must happen BEFORE `generate-tsd`, otherwise the emitted .d.ts
+// declarations would be deleted before the Vite bundles are generated.
+fs.rmSync('./dist', { recursive: true, force: true })


### PR DESCRIPTION
The dist clean step added in 0.0.13 ran inside scripts/build.js, after generate-tsd had already emitted the .d.ts files into dist, deleting them before the Vite bundles were generated. The published 0.0.13 package therefore shipped without any TypeScript declarations, causing "Could not find a declaration file for module '@volverjs/ui-vue/...'".

Move the dist cleanup into a dedicated scripts/clean.js and run it as a separate `clean` npm step before `generate-tsd`, so declarations are emitted after the cleanup and preserved alongside the Vite output (every build() uses emptyOutDir: false).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing TypeScript declaration files in published packages. The build process has been optimized to ensure type declarations are properly included in all releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->