### PR TITLE
feat(VvTab): add lazy panel rendering strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.16] - 2026-07-20
+
+### Added
+
+- `VvTab` new prop `lazy` to control panel rendering: `false` (default) renders every panel eagerly, `true` renders only the currently active panel, `'once'` renders a panel on first activation and keeps it mounted afterwards.
+
 ## [0.0.15] - 2026-06-17
 
 ### Fixed

--- a/src/components/VvTab/VvTab.vue
+++ b/src/components/VvTab/VvTab.vue
@@ -46,6 +46,24 @@ const navItems = computed(() =>
     })),
 )
 
+// lazy panels: track visited tabs to support the 'once' strategy
+const visitedTabs = ref(new Set<string>())
+watch(
+    activeTabKey,
+    (newValue) => {
+        if (newValue) {
+            visitedTabs.value.add(newValue)
+        }
+    },
+    { immediate: true },
+)
+function isPanelRendered(tab: string) {
+    if (!props.lazy || activeTabKey.value === tab) {
+        return true
+    }
+    return props.lazy === 'once' && visitedTabs.value.has(tab)
+}
+
 // bem css classes
 const bemCssClasses = useModifiers('vv-tab', modifiers)
 </script>
@@ -75,7 +93,7 @@ export default {
         <!-- #region panels -->
         <template v-for="(item, index) in items" :key="index">
             <article
-                v-if="item.tab"
+                v-if="item.tab && isPanelRendered(item.tab)"
                 :class="{ target: activeTabKey === item.tab }"
                 class="vv-tab__panel"
             >

--- a/src/components/VvTab/index.ts
+++ b/src/components/VvTab/index.ts
@@ -14,6 +14,16 @@ export const VvTabProps = {
         type: Array as PropType<NavItemTab[]>,
         default: () => [],
     },
+    /**
+     * Panel rendering strategy:
+     * false (default) renders every panel eagerly,
+     * true renders only the active panel,
+     * 'once' renders a panel on first activation and keeps it mounted.
+     */
+    lazy: {
+        type: [Boolean, String] as PropType<boolean | 'once'>,
+        default: false,
+    },
 }
 
 export const VvTabEvents = ['update:modelValue']


### PR DESCRIPTION
## Summary

Add a `lazy` prop to `VvTab` to control how panels are rendered:

- `false` (default): renders every panel eagerly (previous behavior, no change).
- `true`: renders only the currently active panel.
- `'once'`: renders a panel on first activation and keeps it mounted afterwards.

## Notes

- No behavior change for existing usages: `lazy` defaults to `false`.
- Changelog updated with a `0.0.16` entry.

## Verification

- `type-check`: pass
- `lint`: pass
- `build`: pass
- `test-storybook` (vitest): 91 files / 343 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable lazy rendering for tab panels.
  - Panels can render eagerly, only while active, or render once upon first activation and remain mounted.
  - The new setting defaults to the existing eager-rendering behavior.
- **Documentation**
  - Added release notes describing the new tab panel rendering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->