### PR TITLE
ci: upload the Pages artifact with an action that runs on Node.js 24

### DIFF
--- a/.github/workflows/styleguide.yml
+++ b/.github/workflows/styleguide.yml
@@ -36,8 +36,12 @@ jobs:
             - name: Setup GitHub Pages
               uses: actions/configure-pages@v6
 
+            # v4 pins actions/upload-artifact 4.6.2 internally, which still
+            # targets Node.js 20 and makes every run of this job warn about the
+            # deprecation. v5 is the same composite action with the pin moved to
+            # upload-artifact 7, so it runs on Node.js 24. Same inputs.
             - name: Upload styleguide
-              uses: actions/upload-pages-artifact@v4
+              uses: actions/upload-pages-artifact@v5
               with:
                   name: 'github-pages'
                   path: './storybook-static'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- The styleguide workflow uploads the Pages artifact with `actions/upload-pages-artifact@v5`. Version 4 pins `actions/upload-artifact` 4.6.2 inside itself, which still targets Node.js 20, so every run of that job ended with the runner deprecation warning. It was the only one left in the pipeline. Version 5 is the same composite action with the pin moved to `actions/upload-artifact` 7, and it takes the same inputs.
+
 ## [0.0.18] - 2026-08-31
 
 ### Changed


### PR DESCRIPTION
Closes the Node.js 20 deprecation warning on `build-styleguide / build`:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02`.

## Where it came from

That SHA is `actions/upload-artifact` 4.6.2, and no workflow references it directly. `actions/upload-pages-artifact@v4` pins it inside its own composite action:

```yaml
# actions/upload-pages-artifact @ v4.0.0, action.yml:80
uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
```

`v5.0.0` is the same action with that pin moved forward:

```yaml
# actions/upload-pages-artifact @ v5.0.0, action.yml:84
uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
```

Its changelog carries exactly two entries, the upload-artifact bump and a new optional `include-hidden-files` input this workflow does not use. `name` and `path` are unchanged, so the step keeps its current form.

## Scope

This was the only deprecation warning left in the pipeline. The annotations of the whole `v0.0.18` Main pipeline run (`33370509830`, seven jobs, all green) carry that one message and nothing else.

## Not in this pull request

Several actions have newer majors available without emitting any warning, since the repository has no `dependabot.yml` covering the `github-actions` ecosystem and nothing bumps them: `actions/checkout` v5 to v7, `actions/setup-node` v5 to v7, `actions/download-artifact` v7 to v8, `actions/upload-artifact` v6 to v7. Worth doing separately, so a failure there is not confused with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)