### PR TITLE
fix(deps): @volverjs/style 0.1.26 and a peer floor, for a dressed VvInputRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
 
   The failure is not the platform slider showing through. The reset of `@volverjs/style` applies `all: unset` to every element outside a short exclusion list, and `input[type="range"]` is not in it, so a control the library does not dress keeps no appearance of its own. The 0.0.19 entry said otherwise and is corrected there.
 
-  Nothing changes for an application that already installs `@volverjs/style` 0.1.26: the published package never carried the style, which stays a peer dependency. What this release rebuilds is the styleguide.
+  The published package never carried the style, so what this release rebuilds is the styleguide, and an application already on 0.1.26 has nothing to do.
+- The `@volverjs/style` peer dependency declares a floor for the first time, `>=0.1.26` in place of `>=0`. A component whose style is missing does not fail loudly, it renders undressed, and the changelog was the only place saying which release it needed. An application still on an older style now hears about it while installing rather than while looking at a slider with no track. Package managers configured to refuse unmet peers will hold the upgrade until `@volverjs/style` moves too, which is the intent: the two are one design system.
 - A story asserts that the enabled slider computes `cursor: pointer`, which the dressed control sets and `all: unset` does not, so the suite fails if a component is ever released ahead of its style again.
 
 ## [0.0.19] - 2026-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ All notable changes to this project will be documented in this file.
 
   It takes no `readonly` attribute either, so `readonly` disables the native control and adds the `--readonly` modifier, the same shape `VvCheckbox`, `VvRadio` and `VvSelect` already use.
 
-  CSS cannot read the value of a range input, so the component writes the filled share of the track on the block as `--input-range-progress`. It needs the `@volverjs/style` release that ships `vv-input-range`: without it the field renders as the platform slider.
+  CSS cannot read the value of a range input, so the component writes the filled share of the track on the block as `--input-range-progress`. It needs `@volverjs/style` 0.1.26, the release that ships `vv-input-range`. Not as a nicety: the reset of the style library unsets the user agent appearance of every control it does not dress itself, so without that release the field renders as a bare thumb with no track under it.
 - `InputRange` in the json-render catalog and registry, which now declare 27 components.
 
 ### Changed
 
+- `@volverjs/style` moves to 0.1.26 among the development dependencies, the release that ships `vv-input-range`. The styleguide was drawing the new field as a bare thumb, because the component was there and the style that dresses it was not.
 - Development dependencies updated, among them `storybook` and its addons to 10.6.0, `@antfu/eslint-config` to 9.5.1, `eslint` to 10.10.0, `playwright` to 1.63.0, `sass-embedded` to 1.104.0, `@iconify/utils` to 3.1.7 and `@types/node` to 26.4.1, and `packageManager` moves to pnpm 12.3.4.
 
   `vitest` and the two `@vitest/browser` packages join `typescript` in the reject list of `.ncurc.yml`: Vitest 5 is not supported by `@storybook/addon-vitest`, which peers on `vitest ^3 || ^4` up to and including its 11.0.0 alpha, and installing it makes the storybook project fail to import `.storybook/vitest.setup.ts`, so the suite collects its files and runs no test. They need no `overrides` entry, because nothing pulls vitest transitively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.20] - 2026-09-07
+
+### Fixed
+
+- `VvInputRange` is dressed again. `@volverjs/style` moves to 0.1.26 among the development dependencies, the release that ships `vv-input-range`: 0.0.19 published the component while the style that draws it was still missing, and the styleguide rendered the field as a bare thumb sitting on no track.
+
+  The failure is not the platform slider showing through. The reset of `@volverjs/style` applies `all: unset` to every element outside a short exclusion list, and `input[type="range"]` is not in it, so a control the library does not dress keeps no appearance of its own. The 0.0.19 entry said otherwise and is corrected there.
+
+  Nothing changes for an application that already installs `@volverjs/style` 0.1.26: the published package never carried the style, which stays a peer dependency. What this release rebuilds is the styleguide.
+- A story asserts that the enabled slider computes `cursor: pointer`, which the dressed control sets and `all: unset` does not, so the suite fails if a component is ever released ahead of its style again.
+
 ## [0.0.19] - 2026-09-07
 
 ### Added
@@ -19,7 +30,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- `@volverjs/style` moves to 0.1.26 among the development dependencies, the release that ships `vv-input-range`. The styleguide was drawing the new field as a bare thumb, because the component was there and the style that dresses it was not.
 - Development dependencies updated, among them `storybook` and its addons to 10.6.0, `@antfu/eslint-config` to 9.5.1, `eslint` to 10.10.0, `playwright` to 1.63.0, `sass-embedded` to 1.104.0, `@iconify/utils` to 3.1.7 and `@types/node` to 26.4.1, and `packageManager` moves to pnpm 12.3.4.
 
   `vitest` and the two `@vitest/browser` packages join `typescript` in the reject list of `.ncurc.yml`: Vitest 5 is not supported by `@storybook/addon-vitest`, which peers on `vitest ^3 || ^4` up to and including its 11.0.0 alpha, and installing it makes the storybook project fail to import `.storybook/vitest.setup.ts`, so the suite collects its files and runs no test. They need no `overrides` entry, because nothing pulls vitest transitively.

--- a/package.json
+++ b/package.json
@@ -423,7 +423,7 @@
   "peerDependencies": {
     "@json-render/core": ">=0.19.0",
     "@json-render/vue": ">=0.19.0",
-    "@volverjs/style": ">=0",
+    "@volverjs/style": ">=0.1.26",
     "@vueuse/core": ">=14",
     "vue": ">=3",
     "zod": ">=4"

--- a/package.json
+++ b/package.json
@@ -484,7 +484,7 @@
     "@vitejs/plugin-vue": "^6.0.8",
     "@vitest/browser": "^4.1.11",
     "@vitest/browser-playwright": "^4.1.11",
-    "@volverjs/style": "0.1.25",
+    "@volverjs/style": "0.1.26",
     "@vue/compiler-sfc": "^3.5.42",
     "@vue/eslint-config-typescript": "^14.9.0",
     "@vue/test-utils": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,8 +237,8 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(playwright@1.63.0)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(yaml@2.9.0))(vitest@4.1.11)
       '@volverjs/style':
-        specifier: 0.1.25
-        version: 0.1.25
+        specifier: 0.1.26
+        version: 0.1.26
       '@vue/compiler-sfc':
         specifier: ^3.5.42
         version: 3.5.42
@@ -2611,8 +2611,8 @@ packages:
       typescript:
         optional: true
 
-  '@volverjs/style@0.1.25':
-    resolution: {integrity: sha512-6W03KO9VPpr+UvyGMlOYCpU3pzASz4K0CJ/LpEi3jKPA80qwsSadwl9qKHnQVfTSk8sls4iNF5eOlAUP3lBKXA==}
+  '@volverjs/style@0.1.26':
+    resolution: {integrity: sha512-4YZ/ABE5S9xwu7FBDEdtyH/5aXr2CIFO9TFjuLGCqWnvfZZfqKkDi660FxOiMz2P+XjLEvrNJVv4J/im2rSUYA==}
     engines: {node: '>= 20.x'}
 
   '@vue/compiler-core@3.5.40':
@@ -2838,11 +2838,6 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
-
-  baseline-browser-mapping@2.11.20:
-    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   baseline-browser-mapping@2.11.21:
     resolution: {integrity: sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==}
@@ -8192,7 +8187,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@volverjs/style@0.1.25': {}
+  '@volverjs/style@0.1.26': {}
 
   '@vue/compiler-core@3.5.40':
     dependencies:
@@ -8418,8 +8413,6 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.20: {}
-
   baseline-browser-mapping@2.11.21: {}
 
   blurhash@2.0.5: {}
@@ -8457,7 +8450,7 @@ snapshots:
 
   browserslist@4.28.9:
     dependencies:
-      baseline-browser-mapping: 2.11.20
+      baseline-browser-mapping: 2.11.21
       caniuse-lite: 1.0.30001810
       electron-to-chromium: 1.5.422
       node-releases: 2.0.54

--- a/skills/volverjs-ui-vue/SKILL.md
+++ b/skills/volverjs-ui-vue/SKILL.md
@@ -93,7 +93,7 @@ but only the modifiers declared by `@volverjs/style` do anything. Components als
 their own (`--disabled`, `--icon-only`, `--reverse`, `--floating`, `--valid`, `--invalid`,
 `--readonly`), so do not pass those by hand.
 
-Declared by `@volverjs/style` 0.1.25 (regenerate with `scripts/list-modifiers.sh` when the version changes):
+Declared by `@volverjs/style` 0.1.26 (regenerate with `scripts/list-modifiers.sh` when the version changes):
 
 | Component | Modifiers |
 |-----------|-----------|
@@ -111,6 +111,7 @@ Declared by `@volverjs/style` 0.1.25 (regenerate with `scripts/list-modifiers.sh
 | vv-accordion-group | `condensed` |
 | vv-checkbox-group | `horizontal` |
 | vv-input-file | `drop-area` `square` `circle` `hidden` `with-progress` |
+| vv-input-range | `valid` `invalid` `readonly`, all three set by the component |
 | vv-textarea | `resizable` |
 | vv-nav | `sidebar` `aside` `tabs` `full` |
 | vv-tooltip | `visible` `top` `bottom` `left` |

--- a/src/stories/InputRange/InputRange.test.ts
+++ b/src/stories/InputRange/InputRange.test.ts
@@ -19,6 +19,14 @@ export async function defaultTest({ canvasElement, args }: PlayAttributes) {
     await expect(element).toHaveClass('vv-input-range')
     await expect(element.tagName).toEqual('DIV')
 
+    // The field is dressed by the `vv-input-range` of @volverjs/style. The
+    // reset of that library unsets the user agent appearance of every control
+    // it does not dress, so a release without it leaves a bare thumb and no
+    // track: this is what that looks like from here.
+    if (!args.disabled && !args.readonly) {
+        await expect(getComputedStyle(input).cursor).toEqual('pointer')
+    }
+
     // The field reports the middle of its track until it has a value, and the
     // fill, the readout and the model have to say the same.
     await expect(value.innerHTML).toEqual('50')


### PR DESCRIPTION
`VvInputRange` shipped in 0.0.19 before the style that draws it, so the styleguide published with that release renders the new field as a bare thumb with no track under it. This opens 0.0.20 to fix it.

## What happened

`@volverjs/style` 0.1.25, the version this repository developed against, has no `vv-input-range`: neither the component stylesheet nor its settings map. That alone would have left the platform slider, but the reset of that library gets there first, applying `all: unset` to every element outside a short exclusion list. An `input[type="range"]` is in scope, so it loses its user agent appearance and nothing puts one back.

The 0.0.19 changelog claimed the field would render as the platform slider without that release. It does not, and the entry is corrected.

## The fix

`@volverjs/style` 0.1.26 ships `vv-input-range`. The bump is all it takes: the generated selectors reach the bare control through an alias, `:where(.vv-input-range__input, .vv-input-range input[type=range])`, so no class has to move onto the input, and the track reads the `--input-range-progress` the component already writes on the block. The three modifiers it declares, `valid`, `invalid` and `readonly`, are the ones the component already sets.

## The peer dependency declares a floor

`@volverjs/style` moves from `>=0` to `>=0.1.26` in `peerDependencies`. A component whose style is missing does not fail loudly, it renders undressed, and until now the changelog was the only place recording which release a component needed. An application already on 0.1.26 sees no change; one on an older style now hears about it while installing, and a package manager set to refuse unmet peers holds the upgrade until the style moves too.

This is the one part of the release that reaches the published package. The style was never bundled, so for everything else 0.0.20 is 0.0.19 with a styleguide built against a style that dresses the component.

## Guard

`defaultTest` now asserts the enabled slider computes `cursor: pointer`. The dressed control sets it, while `all: unset` leaves the cursor inherited, so the check fails if a component is ever released ahead of its style again, without reaching into a vendor pseudo element.

## Verified

`InputRange` at 13 tests and the full suite at 362 across 94 files, with typecheck and lint clean. One unrelated flake appeared on `ComboboxOptions` under heavy machine load, a failed dynamic import rather than an assertion; the file passes on its own with its 6 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
