### PR TITLE
fix(a11y): aria-labelledby only when its target renders, and props to name a field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `ariaLabel`, `ariaLabelledby` and `ariaDescribedby` on `VvCombobox`, `VvSelect`, `VvInputText` and `VvTextarea`, so a field can be named and described from outside. `label` is optional on every one of them, and until now a field drawn without one had no way to be named at all: the attribute a caller wrote landed on the block, where it named a wrapper nobody operates, and left the control the user reaches anonymous.
+
+  They are declared props rather than attributes read out of `$attrs`, which is the other way to do it and the way `VvInputRange` does it. Declaring them is what moves them off the block, since Vue takes a declared prop out of `$attrs`, and it leaves the routing of everything else exactly as it was: `class`, `style` and the `data-` hooks a page puts on a field keep addressing the block. The call site does not change shape either, because Vue matches the kebab-case attribute to the camelCase prop, so `<VvSelect aria-label="Ward" />` reads the same here as it does on the slider.
+
+  Note what this moves in the DOM: an application that already writes `aria-label` on one of these four components will find it on the control instead of on the block. It did nothing useful on the block, but a selector or a snapshot that expected it there needs updating.
+
+  `aria-describedby` is the one of the three that does not override. It takes a list of ids, so a field with a hint of its own appends the hint to what the caller pointed at instead of dropping either, the caller's ids first, which is the order the two are read in. The list is not deduplicated, matching `VvInputRange`: a caller that includes the field's own hint id gets it announced twice.
+
+  The two mechanisms now sit side by side, and they are not equivalent. `VvInputRange` forwards every `aria-` attribute to its control, these four forward exactly these three, so something like `aria-details` reaches the slider and stays on the block everywhere else.
+
+### Fixed
+
+- `VvAlert` and `VvCombobox` bound `aria-labelledby` unconditionally while the element carrying that id is conditional, so both pointed at an id that is not in the document whenever it was absent. A reference to a missing element names nothing, which left the control looking named while it was not: for `VvCombobox` that is a `role="combobox"`, which does require an accessible name, and for an `alertdialog` it hid that nothing named the dialog.
+
+  On the alert the condition is a title and no `header` slot, which is the half that is easy to miss: the header slot replaces the whole default header, title included, so an alert with a custom header renders no title element even when `title` is set. The attribute moved out of `useVvAlert`'s `hasProps` and into the template for that reason, since whether a slot was passed is a render-time question and a computed does not track it.
+
+  Neither was caught by the suite because every `Alert` story passes a title and every `Combobox` story passes a label, so the shape with neither was never drawn. Both now have a story that draws it, and the accessibility assertion in `Combobox.test.ts`, which had been commented out, runs again.
+
 ## [0.0.20] - 2026-09-07
 
 ### Fixed

--- a/src/components/VvAlert/VvAlert.vue
+++ b/src/components/VvAlert/VvAlert.vue
@@ -20,7 +20,25 @@ export default {
 </script>
 
 <template>
-    <div v-bind="hasProps">
+    <!--
+        `aria-labelledby` may only be bound when the `vv-alert__title` element
+        below actually renders, or it points at an id that is not in the
+        document. That means a title, and no `header` slot: the header slot
+        replaces the whole default header, title included, and it takes no slot
+        prop for the id, so an alert with a custom header cannot say what names
+        it. Leaving the attribute off is right in both cases: `role=alert` is a
+        live region, so its content is announced when it appears whether or not
+        the container carries a name, and the role does not require one. An
+        `alertdialog` does, and there the absence is the honest signal: a
+        reference to a missing id would not have named it either, it would only
+        have hidden that nothing does.
+    -->
+    <div
+        v-bind="hasProps"
+        :aria-labelledby="
+            !$slots.header && ($slots.title || title) ? hasTitleId : undefined
+        "
+    >
         <div
             v-if="
                 $slots.header

--- a/src/components/VvAlert/index.ts
+++ b/src/components/VvAlert/index.ts
@@ -158,13 +158,21 @@ export function useVvAlert(props: Readonly<ExtractPropTypes<typeof VvAlertProps>
         close,
         hasIcon,
         hasTitleId,
+        // NB `aria-labelledby` is deliberately not in here. The element holding
+        // `hasTitleId` only renders when a `title` prop or slot is given, so
+        // binding the attribute unconditionally left a content-only alert
+        // pointing at an id that does not exist: invalid ARIA that names
+        // nothing, and for `role="alertdialog"` it hid the fact that the dialog
+        // has no name at all. Whether the title renders is a question about
+        // slots, which are read at render time and not tracked by a computed,
+        // so VvAlert.vue binds the attribute where it also decides to draw the
+        // title.
         hasProps: computed(() => ({
             onMouseover,
             onMouseleave,
-            'class': hasClass.value,
-            'style': hasStyle.value,
-            'role': props.role,
-            'aria-labelledby': hasTitleId.value,
+            class: hasClass.value,
+            style: hasStyle.value,
+            role: props.role,
         })),
     }
 }

--- a/src/components/VvCombobox/VvCombobox.vue
+++ b/src/components/VvCombobox/VvCombobox.vue
@@ -160,6 +160,20 @@ const hasDropdownId = computed(() => `${hasId.value}-dropdown`)
 const hasSearchId = computed(() => `${hasId.value}-search`)
 const hasLabelId = computed(() => `${hasId.value}-label`)
 
+// `aria-describedby` takes a list of ids, so the field's own hint joins what the
+// caller pointed at instead of replacing it. Caller first: that is the order the
+// two are read in. A computed and not a template expression only because the
+// template has no room for it.
+const hasDescribedby = computed(
+    () =>
+        [
+            props.ariaDescribedby,
+            hasHintLabelOrSlot.value ? hasHintId.value : undefined,
+        ]
+            .filter(Boolean)
+            .join(' ') || undefined,
+)
+
 // tabindex
 const isDisabledOrReadonly = computed(() => props.disabled || props.readonly)
 const hasTabindex = computed(() => {
@@ -468,6 +482,13 @@ const selectProps = computed(() => ({
     autoselectFirst: propsDefaults.value.autoselectFirst,
     multiple: propsDefaults.value.multiple,
     label: propsDefaults.value.label,
+    // The native fallback is a VvSelect, so the name and the description have
+    // to travel with the rest: a `native` combobox with no visible label would
+    // otherwise be the one shape left anonymous. VvSelect does its own hint
+    // merging, so `ariaDescribedby` goes over raw rather than pre-joined.
+    ariaLabel: props.ariaLabel,
+    ariaLabelledby: props.ariaLabelledby,
+    ariaDescribedby: props.ariaDescribedby,
     placeholder: propsDefaults.value.placeholder,
     modelValue: props.modelValue,
 }))
@@ -589,10 +610,35 @@ export default {
                     </div>
                     <div class="vv-select__inner">
                         <VvIcon v-if="hasIconBefore" v-bind="hasIconBefore" class="vv-select__icon" />
+                        <!--
+                            A `role="combobox"` needs an accessible name, and
+                            this is where it comes from. Three notes, in the
+                            order they bite:
+
+                            `aria-labelledby` mirrors the `v-if` on the <label>
+                            above and has to keep mirroring it: bound
+                            unconditionally it pointed at an id that is not in
+                            the document whenever no `label` was given, which
+                            left the control anonymous while looking named. It
+                            reads the raw `label` prop, exactly as the <label>
+                            does, and not `propsDefaults.label`.
+
+                            An explicit `ariaLabelledby` wins over that, since
+                            passing it is a deliberate override. Falsy and not
+                            nullish: Vue keeps an empty string and renders a
+                            bare `aria-labelledby`, which is the same empty
+                            reference this whole block exists to avoid.
+
+                            These are props and not attributes because an
+                            attribute would land on the block: see the note on
+                            `AriaProps` in ../../props.
+                        -->
                         <div
                             ref="inputEl" v-bind="aria" class="vv-select__input" role="combobox"
-                            :aria-controls="hasDropdownId" :aria-expanded="expanded" :aria-labelledby="hasLabelId"
-                            :aria-describedby="hasHintLabelOrSlot ? hasHintId : undefined"
+                            :aria-controls="hasDropdownId" :aria-expanded="expanded"
+                            :aria-label="ariaLabel || undefined"
+                            :aria-labelledby="ariaLabelledby || (label ? hasLabelId : undefined)"
+                            :aria-describedby="hasDescribedby"
                             :aria-errormessage="hasInvalidLabelOrSlot ? hasHintId : undefined" :tabindex="hasTabindex"
                             @click.passive="onClickInput"
                         >

--- a/src/components/VvCombobox/index.ts
+++ b/src/components/VvCombobox/index.ts
@@ -2,6 +2,7 @@ import type { MaybeElement } from '@vueuse/core'
 import type { PropType } from 'vue'
 import type { Option } from '../../types/generic'
 import {
+    AriaProps,
     ClearProps,
     DisabledProps,
     DropdownProps,
@@ -48,6 +49,7 @@ export const VvComboboxProps = {
     ...FloatingLabelProps,
     ...DropdownProps,
     ...LabelProps,
+    ...AriaProps,
     ...RequiredProps,
     ...ClearProps,
     /**

--- a/src/components/VvInputText/VvInputText.vue
+++ b/src/components/VvInputText/VvInputText.vue
@@ -594,10 +594,23 @@ const hasAttrs = computed(() => {
         'readonly': props.readonly,
         'required': props.required,
         'autocomplete': props.autocomplete,
+        // For an input drawn without a visible `label`, which is allowed: see
+        // the note on `AriaProps` in ../../props. A search field with only a
+        // placeholder is the usual case.
+        // `|| undefined`: Vue keeps an empty string and renders a bare
+        // attribute, i.e. an empty name or reference.
+        'aria-label': props.ariaLabel || undefined,
+        'aria-labelledby': props.ariaLabelledby || undefined,
         'aria-invalid': isInvalid.value,
-        'aria-describedby': hasHintLabelOrSlot.value
-            ? hasHintId.value
-            : undefined,
+        // A list of ids, so the field's own hint joins what the caller pointed
+        // at instead of replacing it. Caller first: that is the reading order.
+        'aria-describedby':
+            [
+                props.ariaDescribedby,
+                hasHintLabelOrSlot.value ? hasHintId.value : undefined,
+            ]
+                .filter(Boolean)
+                .join(' ') || undefined,
         'aria-errormessage': hasInvalidLabelOrSlot.value
             ? hasHintId.value
             : undefined,

--- a/src/components/VvSelect/VvSelect.vue
+++ b/src/components/VvSelect/VvSelect.vue
@@ -180,10 +180,25 @@ const hasAttrs: SelectHTMLAttributes = computed(() => {
         'size': props.size,
         'autocomplete': props.autocomplete,
         'multiple': props.multiple,
+        // `label` is optional, so a select can be drawn with no <label> to be
+        // associated with: these give it a name anyway. They sit on the control
+        // and not on the block for the same reason every other `aria-` here
+        // does, and they take precedence over a visible label, which is why the
+        // prop documents when not to use them.
+        // `|| undefined` and not the raw prop: Vue keeps an empty string and
+        // renders a bare attribute, i.e. an empty name or reference.
+        'aria-label': props.ariaLabel || undefined,
+        'aria-labelledby': props.ariaLabelledby || undefined,
         'aria-invalid': isInvalid.value,
-        'aria-describedby': hasHintLabelOrSlot.value
-            ? hasHintId.value
-            : undefined,
+        // A list of ids, so the field's own hint joins what the caller pointed
+        // at instead of replacing it. Caller first: that is the reading order.
+        'aria-describedby':
+            [
+                props.ariaDescribedby,
+                hasHintLabelOrSlot.value ? hasHintId.value : undefined,
+            ]
+                .filter(Boolean)
+                .join(' ') || undefined,
         'aria-errormessage': hasInvalidLabelOrSlot.value
             ? hasHintId.value
             : undefined,

--- a/src/components/VvSelect/index.ts
+++ b/src/components/VvSelect/index.ts
@@ -1,6 +1,7 @@
 import type { MaybeElement } from '@vueuse/core'
 import type { Option } from '../../types/generic'
 import {
+    AriaProps,
     AutocompleteProps,
     AutofocusProps,
     ClearProps,
@@ -44,6 +45,7 @@ export const VvSelectProps = {
     ...FloatingLabelProps,
     ...UnselectableProps,
     ...LabelProps,
+    ...AriaProps,
     ...ClearProps,
     /**
      * This Boolean attribute indicates that multiple options can be selected in the list.

--- a/src/components/VvTextarea/VvTextarea.vue
+++ b/src/components/VvTextarea/VvTextarea.vue
@@ -231,10 +231,22 @@ const hasAttrs = computed(
             'rows': props.rows,
             'wrap': props.wrap,
             'spellcheck': props.spellcheck,
+            // For a textarea drawn without a visible `label`, which is allowed:
+            // see the note on `AriaProps` in ../../props.
+            // `|| undefined`: Vue keeps an empty string and renders a bare
+            // attribute, i.e. an empty name or reference.
+            'aria-label': props.ariaLabel || undefined,
+            'aria-labelledby': props.ariaLabelledby || undefined,
             'aria-invalid': isInvalid.value,
-            'aria-describedby': hasHintLabelOrSlot.value
-                ? hasHintId.value
-                : undefined,
+            // A list of ids, so the field's own hint joins what the caller
+            // pointed at instead of replacing it. Caller first: reading order.
+            'aria-describedby':
+                [
+                    props.ariaDescribedby,
+                    hasHintLabelOrSlot.value ? hasHintId.value : undefined,
+                ]
+                    .filter(Boolean)
+                    .join(' ') || undefined,
             'aria-errormessage': hasInvalidLabelOrSlot.value
                 ? hasHintId.value
                 : undefined,

--- a/src/props/index.ts
+++ b/src/props/index.ts
@@ -182,6 +182,55 @@ export const LabelProps = {
     },
 }
 
+/**
+ * Naming and describing a field from outside. The name matters because `label`
+ * is optional: with neither, the control the user operates has no accessible
+ * name at all.
+ *
+ * These are declared props and not left to `$attrs` on purpose. An attribute
+ * lands on the component's block, so it would name a wrapper the user never
+ * touches and leave the control anonymous. Declaring them takes them out of
+ * `$attrs` as well, so nothing ends up duplicated on the block, while `class`,
+ * `style` and the `data-` hooks a page puts on a field keep addressing it
+ * exactly as before. Vue matches the kebab-case attribute to the camelCase
+ * prop, so the call site is the usual `<VvSelect aria-label="…" />` and reads
+ * the same as it does on `VvInputRange`, which reaches the control by splitting
+ * `$attrs` instead.
+ */
+export const AriaProps = {
+    /**
+     * Accessible name of the control. Use it when no visible label is drawn:
+     * with one on screen, a different `aria-label` replaces the name assistive
+     * technology reads and breaks WCAG 2.5.3 (Label in Name).
+     */
+    ariaLabel: {
+        type: String,
+        default: undefined,
+    },
+    /**
+     * Ids of the elements whose text names the control, for a name that is
+     * already written on the page. Takes precedence over the component's own
+     * `label`, per the accessible name computation.
+     */
+    ariaLabelledby: {
+        type: String,
+        default: undefined,
+    },
+    /**
+     * Ids of the elements that describe the control, for help text the page
+     * already draws elsewhere.
+     *
+     * Unlike the two above this one does not replace what the component has to
+     * say: `aria-describedby` takes a *list* of ids, so a field with a hint of
+     * its own appends the hint rather than dropping either. The caller's ids
+     * come first, which is the order they are read in.
+     */
+    ariaDescribedby: {
+        type: String,
+        default: undefined,
+    },
+}
+
 export const ReadonlyProps = {
     /**
      * The value is not editable
@@ -468,6 +517,7 @@ export const InputTextareaProps = {
     ...IconProps,
     ...FloatingLabelProps,
     ...LabelProps,
+    ...AriaProps,
     /**
      * Input / Textarea minlength
      * Minimum length (number of characters) of value

--- a/src/stories/Alert/Alert.stories.ts
+++ b/src/stories/Alert/Alert.stories.ts
@@ -58,3 +58,17 @@ export const Icon: Story = {
         icon: 'warning',
     },
 }
+
+/**
+ * An alert is often just a line of text, with nothing to head it. Every other
+ * story passes a title, which is why this one exists: without a title there is
+ * no element for `aria-labelledby` to point at, and the attribute has to be
+ * left off rather than left dangling.
+ */
+export const ContentOnly: Story = {
+    ...Default,
+    args: {
+        ...defaultArgs,
+        title: undefined,
+    },
+}

--- a/src/stories/Alert/Alert.test.ts
+++ b/src/stories/Alert/Alert.test.ts
@@ -92,6 +92,23 @@ export async function defaultTest({ canvasElement, args }: PlayAttributes) {
         )
     }
 
+    // aria-labelledby
+    // The id it points at belongs to the title element, so the attribute may
+    // only be there when that element is: a reference to an id that is not in
+    // the document names nothing, and axe reports it as `aria-valid-attr-value`.
+    // A `header` slot is the case that is easy to miss, since it replaces the
+    // default header and takes the title with it even when `title` is set.
+    const alertTitleEl = element.getElementsByClassName('vv-alert__title')?.[0]
+    if (args.title && !args.header) {
+        expect(alertTitleEl).not.toBeUndefined()
+        expect(element.getAttribute('aria-labelledby')).toEqual(
+            alertTitleEl?.id,
+        )
+    } else {
+        expect(alertTitleEl).toBeUndefined()
+        expect(element.hasAttribute('aria-labelledby')).toEqual(false)
+    }
+
     // check accessibility
     await expect(element).toHaveNoViolations()
 }

--- a/src/stories/Combobox/Combobox.stories.ts
+++ b/src/stories/Combobox/Combobox.stories.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import VvCombobox from '@/components/VvCombobox/VvCombobox.vue'
 import VvInputText from '@/components/VvInputText/VvInputText.vue'
 import { argTypes, defaultArgs } from './Combobox.settings'
-import { defaultTest } from './Combobox.test'
+import { ariaDescribedbyTest, ariaLabelTest, defaultTest } from './Combobox.test'
 
 const meta: Meta<typeof VvCombobox> = {
     title: 'Components/Combobox',
@@ -246,4 +246,61 @@ export const Size: Story = {
             value: String(i + 1),
         })),
     },
+}
+
+/**
+ * A combobox with no visible label, named by `aria-label` instead. `label` is
+ * optional while a `role="combobox"` needs a name, so this is the shape that
+ * had neither: every other story here passes a label, which is why nothing
+ * caught it. The attribute is written in kebab-case at the call site, as it is
+ * on `VvInputRange`, and reaches the control because the component declares it
+ * as a prop.
+ */
+export const AriaLabel: Story = {
+    ...Default,
+    args: {
+        ...defaultArgs,
+        label: undefined,
+    },
+    render: args => ({
+        components: { VvCombobox },
+        setup() {
+            return { args }
+        },
+        data: () => ({ inputValue: undefined }),
+        template: /* html */ `
+			<vv-combobox v-bind="args" v-model="inputValue" aria-label="Reparto" data-testId="element" />
+			<div>Value: <span data-testId="value">{{inputValue}}</span></div>
+		`,
+    }),
+    play: ariaLabelTest,
+}
+
+/**
+ * Help text the page already draws, pointed at from the field. This is the one
+ * of the three that does not override: the field's own `hintLabel` is appended
+ * to the caller's ids rather than replacing them, because `aria-describedby`
+ * takes a list.
+ */
+export const AriaDescribedby: Story = {
+    ...Default,
+    args: {
+        ...defaultArgs,
+        hintLabel: 'Pick the ward you were referred to.',
+    },
+    render: args => ({
+        components: { VvCombobox },
+        setup() {
+            return { args }
+        },
+        data: () => ({ inputValue: undefined }),
+        template: /* html */ `
+			<div>
+				<span id="extra-help">Ask at the desk if the ward is not listed.</span>
+				<vv-combobox v-bind="args" v-model="inputValue" aria-describedby="extra-help" data-testId="element" />
+			</div>
+			<div>Value: <span data-testId="value">{{inputValue}}</span></div>
+		`,
+    }),
+    play: ariaDescribedbyTest,
 }

--- a/src/stories/Combobox/Combobox.test.ts
+++ b/src/stories/Combobox/Combobox.test.ts
@@ -110,11 +110,15 @@ export async function defaultTest({ canvasElement, args }: PlayAttributes) {
     // precedence the template does: a caller's `ariaLabelledby` is a deliberate
     // override and wins over the component's own label, so asserting the
     // internal id unconditionally would fail on a legitimate usage.
+    //
+    // `||` and not `??`, to keep matching the template: an empty string is
+    // falsy but not nullish, and the component falls back to its own label
+    // rather than emitting an empty reference.
     const comboboxEl = element.querySelector('[role="combobox"]')
     const labelEl = element.querySelector('label')
     await expect(labelEl === null).toEqual(!args.label)
     const expectedLabelledby
-        = args.ariaLabelledby ?? (args.label ? labelEl?.id : undefined)
+        = args.ariaLabelledby || (args.label ? labelEl?.id : undefined)
     if (expectedLabelledby) {
         await expect(comboboxEl?.getAttribute('aria-labelledby')).toEqual(
             expectedLabelledby,

--- a/src/stories/Combobox/Combobox.test.ts
+++ b/src/stories/Combobox/Combobox.test.ts
@@ -103,6 +103,64 @@ export async function defaultTest({ canvasElement, args }: PlayAttributes) {
         await expect(hint.innerHTML).toEqual(args.hintLabel)
     }
 
+    // aria-labelledby
+    // It may only be there when the element it names is, or the combobox points
+    // at an id that is not in the document and ends up with no accessible name
+    // while appearing to have one. The expected value follows the same
+    // precedence the template does: a caller's `ariaLabelledby` is a deliberate
+    // override and wins over the component's own label, so asserting the
+    // internal id unconditionally would fail on a legitimate usage.
+    const comboboxEl = element.querySelector('[role="combobox"]')
+    const labelEl = element.querySelector('label')
+    await expect(labelEl === null).toEqual(!args.label)
+    const expectedLabelledby
+        = args.ariaLabelledby ?? (args.label ? labelEl?.id : undefined)
+    if (expectedLabelledby) {
+        await expect(comboboxEl?.getAttribute('aria-labelledby')).toEqual(
+            expectedLabelledby,
+        )
+    } else {
+        await expect(comboboxEl?.hasAttribute('aria-labelledby')).toEqual(false)
+    }
+
     // check accessibility
-    // await expect(element).toHaveNoViolations()
+    await expect(element).toHaveNoViolations()
+}
+
+export async function ariaLabelTest({ canvasElement }: PlayAttributes) {
+    const canvas = within(canvasElement)
+    const element = await canvas.findByTestId('element')
+    const combobox = element.querySelector('[role="combobox"]')
+
+    // Written as a kebab-case attribute at the call site, it binds to the
+    // camelCase prop, so it reaches the control instead of naming the block the
+    // user never operates. Declaring the prop is also what takes it out of
+    // `$attrs`, which is why the block does not carry a copy.
+    await expect(element).not.toHaveAttribute('aria-label')
+    await expect(combobox).toHaveAttribute('aria-label', 'Reparto')
+
+    // No visible label means no element to point at, so the reference has to be
+    // absent rather than dangling.
+    await expect(element.querySelector('label')).toBeNull()
+    await expect(combobox).not.toHaveAttribute('aria-labelledby')
+
+    // The point of all of it: axe agrees the combobox has a name.
+    await expect(element).toHaveNoViolations()
+}
+
+export async function ariaDescribedbyTest({ canvasElement }: PlayAttributes) {
+    const canvas = within(canvasElement)
+    const element = await canvas.findByTestId('element')
+    const combobox = element.querySelector('[role="combobox"]')
+    const hint = element.getElementsByClassName('vv-select__hint')[0]
+
+    // `aria-describedby` is a list of ids, so the hint joins what the caller
+    // pointed at rather than taking its place. This is the one of the three that
+    // merges instead of overriding.
+    const describedBy
+        = combobox?.getAttribute('aria-describedby')?.split(' ') ?? []
+    await expect(describedBy).toContain('extra-help')
+    await expect(describedBy).toContain(hint.id)
+    await expect(element).not.toHaveAttribute('aria-describedby')
+    await expect(element).toHaveNoViolations()
 }

--- a/src/stories/Select/Select.stories.ts
+++ b/src/stories/Select/Select.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import VvSelect from '@/components/VvSelect/VvSelect.vue'
 import { argTypes, defaultArgs } from './Select.settings'
-import { defaultTest } from './Select.test'
+import { ariaDescribedbyTest, ariaLabelTest, defaultTest } from './Select.test'
 
 const meta: Meta<typeof VvSelect> = {
     title: 'Components/Select',
@@ -123,4 +123,57 @@ export const AutoselectFirst: Story = {
         ...defaultArgs,
         autoselectFirst: true,
     },
+}
+
+/**
+ * A select with no visible label, named by `aria-label` instead. `label` is
+ * optional, so this is a shape the other stories never draw: the attribute is
+ * written in kebab-case at the call site, as it is on `VvInputRange`, and
+ * reaches the <select> because the component declares it as a prop.
+ */
+export const AriaLabel: Story = {
+    args: {
+        ...defaultArgs,
+        label: undefined,
+    },
+    render: args => ({
+        components: { VvSelect },
+        setup() {
+            return { args }
+        },
+        data: () => ({ inputValue: undefined }),
+        template: /* html */ `
+        <vv-select v-bind="args" v-model="inputValue" aria-label="Reparto" data-testId="element" />
+        <div>Value: <span data-testId="value">{{inputValue}}</span></div>
+    `,
+    }),
+    play: ariaLabelTest,
+}
+
+/**
+ * Help text the page already draws, pointed at from the field. The one of the
+ * three aria props that does not override: the field's own `hintLabel` is
+ * appended to the caller's ids rather than replacing them, because
+ * `aria-describedby` takes a list.
+ */
+export const AriaDescribedby: Story = {
+    args: {
+        ...defaultArgs,
+        hintLabel: 'Pick the ward you were referred to.',
+    },
+    render: args => ({
+        components: { VvSelect },
+        setup() {
+            return { args }
+        },
+        data: () => ({ inputValue: undefined }),
+        template: /* html */ `
+        <div>
+            <span id="extra-help">Ask at the desk if the ward is not listed.</span>
+            <vv-select v-bind="args" v-model="inputValue" aria-describedby="extra-help" data-testId="element" />
+        </div>
+        <div>Value: <span data-testId="value">{{inputValue}}</span></div>
+    `,
+    }),
+    play: ariaDescribedbyTest,
 }

--- a/src/stories/Select/Select.test.ts
+++ b/src/stories/Select/Select.test.ts
@@ -79,3 +79,35 @@ export async function defaultTest({ canvasElement, args }: PlayAttributes) {
     // check accessibility
     await expect(element).toHaveNoViolations()
 }
+
+export async function ariaLabelTest({ canvasElement }: PlayAttributes) {
+    const canvas = within(canvasElement)
+    const element = await canvas.findByTestId('element')
+    const select = element.getElementsByTagName('select')[0]
+
+    // `label` is optional, so a select can be drawn with no <label> to be
+    // associated with. The name then comes from `aria-label`, and it has to sit
+    // on the control: on the block it would name a wrapper the user never
+    // reaches. Declaring it as a prop is what takes it out of `$attrs`, which is
+    // why the block does not carry a copy.
+    await expect(element).not.toHaveAttribute('aria-label')
+    await expect(select).toHaveAttribute('aria-label', 'Reparto')
+    await expect(element.querySelector('label')).toBeNull()
+    await expect(element).toHaveNoViolations()
+}
+
+export async function ariaDescribedbyTest({ canvasElement }: PlayAttributes) {
+    const canvas = within(canvasElement)
+    const element = await canvas.findByTestId('element')
+    const select = element.getElementsByTagName('select')[0]
+    const hint = element.getElementsByClassName('vv-select__hint')[0]
+
+    // `aria-describedby` is a list of ids, so the hint joins what the caller
+    // pointed at rather than taking its place. This is also the path the native
+    // VvCombobox takes, which hands its own `ariaDescribedby` straight down.
+    const describedBy = select.getAttribute('aria-describedby')?.split(' ') ?? []
+    await expect(describedBy).toContain('extra-help')
+    await expect(describedBy).toContain(hint.id)
+    await expect(element).not.toHaveAttribute('aria-describedby')
+    await expect(element).toHaveNoViolations()
+}


### PR DESCRIPTION
## Two bugs, one root

`VvAlert` and `VvCombobox` bound `aria-labelledby` unconditionally while the element carrying that id is conditional, so both pointed at an id that is not in the document whenever it was absent. A reference to a missing element names nothing, so the control looked named while it was not. For the combobox that node is a `role="combobox"`, which does require an accessible name.

On the alert the condition is a title **and** no `header` slot, which is the half that is easy to miss: the header slot replaces the whole default header, title included, so an alert with a custom header renders no title element even when `title` is set. The binding moved out of `useVvAlert`'s `hasProps` and into the template for that reason: whether a slot was passed is a render-time question, and a computed does not track it.

Neither was caught by the suite because every `Alert` story passes a title and every `Combobox` story passes a label, so the shape with neither was never drawn. Both now have a story that draws it, and the accessibility assertion in `Combobox.test.ts`, which had been commented out, runs again.

## The gap underneath

`label` is optional on every field, so fixing the dangling reference exposed the real problem: a field drawn without a visible label had no way to be named at all. The attribute a caller wrote landed on the block, where it named a wrapper nobody operates.

`ariaLabel`, `ariaLabelledby` and `ariaDescribedby` now cover `VvCombobox`, `VvSelect`, `VvInputText` and `VvTextarea` (the last two through `InputTextareaProps`).

They are declared props rather than attributes read out of `$attrs`, which is the other way to do it and the way `VvInputRange` does it. Declaring them is what moves them off the block, since Vue takes a declared prop out of `$attrs`, and it leaves everything else routed exactly as before: `class`, `style` and the `data-` hooks keep addressing the block, and `inheritAttrs` stays on. The call site does not change shape, because Vue matches the kebab-case attribute to the camelCase prop, so `<VvSelect aria-label="Ward" />` reads the same here as on the slider.

`aria-describedby` is the one of the three that does not override: it takes a list of ids, so a field with a hint of its own appends the hint to what the caller pointed at, caller first, which is the order the two are read in.

## Breaking, in one narrow way

An application already writing `aria-label` on one of these four components will find it on the control instead of the block. It did nothing useful on the block, but a selector or a snapshot that expected it there needs updating. Nothing in this repo depended on it.

## Two asymmetries left on purpose

- The id list is not deduplicated, matching `VvInputRange`: a caller that includes the field's own hint id gets it announced twice.
- `VvInputRange` forwards **every** `aria-` attribute to its control, these four forward exactly these three, so something like `aria-details` reaches the slider and stays on the block everywhere else.

`VvCheckbox` and `VvRadio` are deliberately untouched: their root *is* the `<label>`, so an `aria-label` there would override visible text and break WCAG 2.5.3 (Label in Name).

## Verification

187 tests across 32 story files (Alert, AlertGroup, Combobox, Select, Textarea, InputText, InputRange), `type-check` and `lint` clean. `InputRange` is included on purpose: it does not compose `InputTextareaProps`, so its `$attrs` split still sees `aria-label` and the two mechanisms are confirmed not to overlap.

The new assertions were checked against their own absence rather than assumed: with the props undeclared on `VvCombobox` but the bindings left in place, `aria-label` lands on the block and the story fails exactly there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Added `aria-label`, `aria-labelledby`, and `aria-describedby` support to comboboxes, selects, text inputs, and textareas.
  - Custom `aria-describedby` references are now combined with component hint descriptions.
  - Improved alert and combobox labeling to avoid references to unavailable elements.
  - Labels are optional when an ARIA label is provided.

- **Documentation**
  - Added changelog entries and accessibility-focused component examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->